### PR TITLE
Add `State::Unknown` to allowed source states for `did-exchange`

### DIFF
--- a/src/protocols/did_exchange/problem_report.rs
+++ b/src/protocols/did_exchange/problem_report.rs
@@ -24,9 +24,11 @@ pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
     let current_state: State = get_current_state(&thid, &problem_report_data.user_type)?.parse()?;
 
     match current_state {
-        State::ReceiveRequest | State::ReceiveResponse => {
-            save_state(thid, &State::SendProblemReport, &problem_report_data.user_type)?
-        }
+        State::Unknown | State::ReceiveRequest | State::ReceiveResponse => save_state(
+            thid,
+            &State::SendProblemReport,
+            &problem_report_data.user_type,
+        )?,
         _ => {
             return Err(Box::from(format!(
                 "Error while processing step: State from {} to {} not allowed",
@@ -64,7 +66,7 @@ pub fn receive_problem_report(_options: &str, message: &str) -> StepResult {
     let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
 
     match current_state {
-        State::SendRequest | State::SendResponse => {
+        State::Unknown | State::SendRequest | State::SendResponse => {
             save_state(&thid, &State::ReceiveProblemReport, &current_user_type)?
         }
         _ => {


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds `State::Unknown` to allowed source states for `did-exchange` protocol handling.

This allows us to send a `problem-report` to declin e an invitation as we are currently not tracking `invitation-received` and `invitation-sent` states (see [spec](https://github.com/hyperledger/aries-rfcs/blob/main/features/0023-did-exchange/README.md#state-machine-tables))
