### PR TITLE
Allow label in invitation

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- allow setting a `label` in the invitation and response message
+
 ### Fixes
 
 ### Deprecations

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -134,6 +134,8 @@ pub struct Base64Container {
 pub struct DidDocumentBodyAttachment<T> {
     #[serde(rename(serialize = "did_doc~attach", deserialize = "did_doc~attach"))]
     pub did_doc_attach: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// Decrypted messaged with dynamic body struct

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -133,6 +133,10 @@ pub fn get_did_exchange_message(
                 did_doc_attach: Base64Container {
                     base64: base64_encoded_did_document,
                 },
+                label: match message.base_message.body.get("label") {
+                    Some(label) => serde_json::from_value(label.clone())?,
+                    None => None,
+                },
             }),
             created_time: None,
             expires_time: None,

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -134,7 +134,7 @@ pub fn get_did_exchange_message(
                     base64: base64_encoded_did_document,
                 },
                 label: match message.base_message.body.get("label") {
-                    Some(label) => serde_json::from_value(label.clone())?,
+                    Some(label) => label.as_str().map(|v| v.to_string()),
                     None => None,
                 },
             }),

--- a/tests/did-exchange.rs
+++ b/tests/did-exchange.rs
@@ -19,7 +19,10 @@ use vade_didcomm::{
         VadeDidCommPluginReceiveOutput,
         VadeDidCommPluginSendOutput,
     },
-    protocols::did_exchange::{DidExchangeOptions, datatypes::{ProblemReportData, ProblemReport, UserType}},
+    protocols::did_exchange::{
+        datatypes::{ProblemReport, ProblemReportData, UserType},
+        DidExchangeOptions,
+    },
 };
 
 const DID_SERVICE_ENDPOINT: &str = "https://evan.network";
@@ -46,7 +49,9 @@ async fn send_request(
             "from": "{}",
             "to": ["{}"],
             "thid": "{}",
-            "body": {{}}
+            "body": {{
+                "label": "test"
+            }}
         }}"#,
         DID_EXCHANGE_PROTOCOL_URL, sender, receiver, id,
     );
@@ -122,6 +127,10 @@ async fn receive_request(
     assert_eq!(target_pub_key, comm_keypair.target_pub_key);
     assert_eq!(pub_key, comm_keypair.pub_key);
     assert_eq!(secret_key, comm_keypair.secret_key);
+    assert_eq!(
+        received.message.body.unwrap().label,
+        Some("test".to_string())
+    );
 
     Ok(())
 }
@@ -584,7 +593,7 @@ async fn can_report_problem() -> Result<(), Box<dyn std::error::Error>> {
         &id,
     )
     .await?;
-    
+
     receive_problem_report(
         &mut vade,
         &test_setup.user1_did,


### PR DESCRIPTION
This PR allows to set the `label` field in the `did-exchange` `request` and `response` message