### PR TITLE
Move storage capabilities into `state_storage` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["portable", "state_storage"]
+default = ["portable"]
 
 debug_db = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["portable"]
+default = ["portable", "state_storage"]
 
 debug_db = []
 
@@ -25,6 +25,8 @@ portable = [
     "didcomm-rs/raw-crypto",
     "didcomm-rs/resolve",
 ]
+
+state_storage = []
 
 wasm = [
     "didcomm-rs/raw-crypto",

--- a/src/db/rocks_db.rs
+++ b/src/db/rocks_db.rs
@@ -66,6 +66,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "state_storage")]
     fn can_use_rocks_db() -> Result<(), Box<dyn std::error::Error>> {
         write_db("test1", "helloooo")?;
         let result = read_db("test1")?;

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -36,15 +36,19 @@ pub fn save_com_keypair(
         target_service_endpoint: service_endpoint.unwrap_or_else(|| String::from("")),
     };
 
-    write_db(
-        &format!("comm_keypair_{}_{}", from_did, to_did),
-        &serde_json::to_string(&comm_keypair)?,
-    )?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            write_db(
+                &format!("comm_keypair_{}_{}", from_did, to_did),
+                &serde_json::to_string(&comm_keypair)?,
+            )?;
 
-    write_db(
-        &format!("key_agreement_key_{}", key_agreement_key),
-        &serde_json::to_string(&comm_keypair)?,
-    )?;
+            write_db(
+                &format!("key_agreement_key_{}", key_agreement_key),
+                &serde_json::to_string(&comm_keypair)?,
+            )?;
+        } else { }
+    }
 
     Ok(comm_keypair)
 }

--- a/src/protocols/did_exchange/problem_report.rs
+++ b/src/protocols/did_exchange/problem_report.rs
@@ -12,31 +12,36 @@ use crate::{
 /// Protocol handler for direction: `send`, type: `DID_EXCHANGE_PROTOCOL_URL/problem-report`
 pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report_message: MessageWithBody<ProblemReportData> = serde_json::from_str(message)?;
-    let problem_report_data = problem_report_message
-        .body
-        .as_ref()
-        .ok_or("missing problem report data in body")?;
-    let thid = &problem_report_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &problem_report_data.user_type)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let problem_report_data = problem_report_message
+                .body
+                .as_ref()
+                .ok_or("missing problem report data in body")?;
+            let thid = &problem_report_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::Unknown | State::ReceiveRequest | State::ReceiveResponse => save_state(
-            thid,
-            &State::SendProblemReport,
-            &problem_report_data.user_type,
-        )?,
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendProblemReport
-            )))
-        }
-    };
+            let current_state: State = get_current_state(&thid, &problem_report_data.user_type)?.parse()?;
+
+            match current_state {
+                State::Unknown | State::ReceiveRequest | State::ReceiveResponse => save_state(
+                    thid,
+                    &State::SendProblemReport,
+                    &problem_report_data.user_type,
+                )?,
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendProblemReport
+                    )))
+                }
+            };
+    } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&problem_report_message)?, "{}")
 }
@@ -44,39 +49,44 @@ pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `DID_EXCHANGE_PROTOCOL_URL/problem-report`
 pub fn receive_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report_message: MessageWithBody<ProblemReportData> = serde_json::from_str(message)?;
-    let problem_report_data = problem_report_message
-        .body
-        .as_ref()
-        .ok_or("missing problem report data in body")?;
-    let thid = problem_report_message
-        .thid
-        .ok_or("Thread id can't be empty")?;
 
-    // flip sides to get current users type
-    let current_user_type = match &problem_report_data.user_type {
-        UserType::Inviter => UserType::Invitee,
-        UserType::Invitee => UserType::Inviter,
-        _ => {
-            return Err(Box::from(format!(
-                "invalid user type for problem report: {}",
-                &problem_report_data.user_type
-            )))
-        }
-    };
-    let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let problem_report_data = problem_report_message
+                .body
+                .as_ref()
+                .ok_or("missing problem report data in body")?;
+            let thid = problem_report_message
+                .thid
+                .ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::Unknown | State::SendRequest | State::SendResponse => {
-            save_state(&thid, &State::ReceiveProblemReport, &current_user_type)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ReceiveProblemReport
-            )))
-        }
-    };
+            // flip sides to get current users type
+            let current_user_type = match &problem_report_data.user_type {
+                UserType::Inviter => UserType::Invitee,
+                UserType::Invitee => UserType::Inviter,
+                _ => {
+                    return Err(Box::from(format!(
+                        "invalid user type for problem report: {}",
+                        &problem_report_data.user_type
+                    )))
+                }
+            };
+            let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+
+            match current_state {
+                State::Unknown | State::SendRequest | State::SendResponse => {
+                    save_state(&thid, &State::ReceiveProblemReport, &current_user_type)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveProblemReport
+                    )))
+                }
+            };
+        } else { }
+    }
 
     generate_step_output(message, "{}")
 }

--- a/src/protocols/did_exchange/response.rs
+++ b/src/protocols/did_exchange/response.rs
@@ -1,3 +1,6 @@
+use rand_core::OsRng;
+use x25519_dalek::{PublicKey, StaticSecret};
+
 use super::helper::{
     get_did_document_from_body,
     get_did_exchange_message,
@@ -7,12 +10,15 @@ use super::helper::{
     DidExchangeType,
 };
 use crate::{
+    datatypes::CommKeyPair,
     get_from_to_from_message,
     keypair::{get_com_keypair, get_key_agreement_key, save_com_keypair},
     protocols::{
-        did_exchange::datatypes::{State, UserType},
-        did_exchange::did_exchange::{get_current_state, save_didexchange, save_state},
-        protocol::{generate_step_output, StepResult}
+        did_exchange::{
+            datatypes::{State, UserType},
+            did_exchange::{get_current_state, save_didexchange, save_state},
+        },
+        protocol::{generate_step_output, StepResult},
     },
 };
 
@@ -25,106 +31,154 @@ pub fn send_response(options: &str, message: &str) -> StepResult {
     let parsed_message: DidExchangeBaseMessage = serde_json::from_str(message)?;
     let options: DidExchangeOptions = serde_json::from_str(options)?;
     let exchange_info = get_from_to_from_message(&parsed_message.base_message)?;
-    let encoded_keypair = get_com_keypair(&exchange_info.from, &exchange_info.to)?;
-    let metadata = serde_json::to_string(&encoded_keypair)?;
-    let pub_key_bytes = hex::decode(encoded_keypair.pub_key)?;
+
+    let pub_key_bytes;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let encoded_keypair = get_com_keypair(&exchange_info.from, &exchange_info.to)?;
+            pub_key_bytes = hex::decode(encoded_keypair.pub_key)?;
+        } else {
+            let secret_key = options
+                .did_exchange_my_secret
+                .map(StaticSecret::from)
+                .ok_or("did_exchange_my_secret is required when sending response without storage")?;
+            let pub_key = PublicKey::from(&secret_key);
+
+            pub_key_bytes = pub_key.to_bytes();
+        }
+    }
+
+    let codec: &[u8] = &[0xec, 0x1];
+    let data = [codec, &pub_key_bytes].concat();
+    let key_agreement_key = format!("did:key:z{}", bs58::encode(data).into_string());
+
     let pub_key_base58_string = &bs58::encode(pub_key_bytes).into_string();
     let (request_message, ..) = get_did_exchange_message(
         DidExchangeType::Response,
         &exchange_info.from,
-        &encoded_keypair.key_agreement_key,
-        &encoded_keypair.target_key_agreement_key,
+        &key_agreement_key,
+        &exchange_info.to,
         &options.service_endpoint.unwrap_or_else(|| "".to_string()),
         pub_key_base58_string,
         &parsed_message,
     )?;
 
-    let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Invitee)?.parse()?;
-    match current_state {
-        State::ReceiveRequest => {
-            save_state(&thid, &State::SendResponse, &UserType::Invitee)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendResponse
-            )))
-        }
-    };
+            let current_state: State = get_current_state(&thid, &UserType::Invitee)?.parse()?;
+            match current_state {
+                State::ReceiveRequest => {
+                    save_state(&thid, &State::SendResponse, &UserType::Invitee)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendResponse
+                    )))
+                }
+            };
 
-    save_didexchange(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&request_message)?,
-        &State::SendResponse,
-    )?;
+            save_didexchange(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&request_message)?,
+                &State::SendResponse,
+            )?;
+    } else { }
+    }
 
-    generate_step_output(&serde_json::to_string(&request_message)?, &metadata)
+    generate_step_output(&serde_json::to_string(&request_message)?, &"{}".to_string())
 }
 
 /// protocol handler for direction: `receive`, type: `DID_EXCHANGE_PROTOCOL_URL/response`
 /// Receives the partners pub key and updates the existing communication key pair for this DID in
 /// the db.
-pub fn receive_response(_options: &str, message: &str) -> StepResult {
+pub fn receive_response(options: &str, message: &str) -> StepResult {
     let parsed_message: DidExchangeBaseMessage = serde_json::from_str(message)?;
     let did_document = get_did_document_from_body(message)?;
     let exchange_info = get_exchange_info_from_message(&parsed_message.base_message, did_document)?;
-    let encoded_keypair = get_key_agreement_key(&exchange_info.to)?;
 
-    let enhanced_encoded_keypair = save_com_keypair(
-        &exchange_info.to,
-        &exchange_info.from,
-        &exchange_info.to,
-        &exchange_info.did_id,
-        &encoded_keypair.pub_key,
-        &encoded_keypair.secret_key,
-        Some(exchange_info.pub_key_hex.to_owned()),
-        Some(exchange_info.service_endpoint.to_owned()),
-    )?;
-    // in case we received a DID document from a known DID and we might be using this documents
-    // DID for communication in future, store key for documents DID as well
-    if exchange_info.from != exchange_info.did_id {
-        save_com_keypair(
-            &exchange_info.to,
-            &exchange_info.from,
-            &exchange_info.to,
-            &exchange_info.did_id,
-            &encoded_keypair.pub_key,
-            &encoded_keypair.secret_key,
-            Some(exchange_info.pub_key_hex),
-            Some(exchange_info.service_endpoint),
-        )?;
+    let comm_key_pair;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let encoded_keypair = get_key_agreement_key(&exchange_info.to)?;
+
+            let enhanced_encoded_keypair = save_com_keypair(
+                &exchange_info.to,
+                &exchange_info.from,
+                &exchange_info.to,
+                &exchange_info.did_id,
+                &encoded_keypair.pub_key,
+                &encoded_keypair.secret_key,
+                Some(exchange_info.pub_key_hex.to_owned()),
+                Some(exchange_info.service_endpoint.to_owned()),
+            )?;
+            // in case we received a DID document from a known DID and we might be using this documents
+            // DID for communication in future, store key for documents DID as well
+            if exchange_info.from != exchange_info.did_id {
+                save_com_keypair(
+                    &exchange_info.to,
+                    &exchange_info.from,
+                    &exchange_info.to,
+                    &exchange_info.did_id,
+                    &encoded_keypair.pub_key,
+                    &encoded_keypair.secret_key,
+                    Some(exchange_info.pub_key_hex),
+                    Some(exchange_info.service_endpoint),
+                )?;
+            }
+            comm_key_pair = &enhanced_encoded_keypair;
+        } else {
+            let options: DidExchangeOptions = serde_json::from_str(options)?;
+            let secret_key = options
+                .did_exchange_my_secret
+                .map(StaticSecret::from)
+                .ok_or("did_exchange_my_secret is required when receiving response without storage")?;
+            let pub_key = PublicKey::from(&secret_key);
+            comm_key_pair = CommKeyPair {
+                pub_key:  hex::encode(pub_key.to_bytes()),
+                secret_key:  hex::encode(secret_key.to_bytes()),
+                key_agreement_key: exchange_info.to,
+                target_key_agreement_key: exchange_info.did_id,
+                target_pub_key: exchange_info.pub_key_hex,
+                target_service_endpoint: exchange_info.service_endpoint,
+            };
+        }
     }
 
-    let metadata = serde_json::to_string(&enhanced_encoded_keypair)?;
+    let metadata = serde_json::to_string(&comm_key_pair)?;
 
-    let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Inviter)?.parse()?;
-    match current_state {
-        State::SendRequest => {
-            save_state(&thid, &State::ReceiveResponse, &UserType::Inviter)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ReceiveResponse
-            )))
-        }
-    };
+            let current_state: State = get_current_state(&thid, &UserType::Inviter)?.parse()?;
+            match current_state {
+                State::SendRequest => {
+                    save_state(&thid, &State::ReceiveResponse, &UserType::Inviter)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveResponse
+                    )))
+                }
+            };
 
-    save_didexchange(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&enhanced_encoded_keypair)?,
-        &State::ReceiveResponse,
-    )?;
+            save_didexchange(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&enhanced_encoded_keypair)?,
+                &State::ReceiveResponse,
+            )?;
+        } else { }
+    }
 
     generate_step_output(message, &metadata)
 }

--- a/src/protocols/issue_credential/done.rs
+++ b/src/protocols/issue_credential/done.rs
@@ -9,25 +9,30 @@ use crate::protocols::{
 /// Protocol handler for direction: `send`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/ack`
 pub fn send_credential_ack(_options: &str, message: &str) -> StepResult {
     let parsed_message: Ack = serde_json::from_str(message)?;
-    let thid = parsed_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(thid, &parsed_message.body.user_type)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = parsed_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::ReceiveIssueCredential => {
-            save_state(thid, &State::Acknowledged, &parsed_message.body.user_type)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "State from {} to {} not allowed",
-                current_state,
-                State::Acknowledged
-            )))
-        }
-    };
+            let current_state: State = get_current_state(thid, &parsed_message.body.user_type)?.parse()?;
+
+            match current_state {
+                State::ReceiveIssueCredential => {
+                    save_state(thid, &State::Acknowledged, &parsed_message.body.user_type)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "State from {} to {} not allowed",
+                        current_state,
+                        State::Acknowledged
+                    )))
+                }
+            };
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&parsed_message)?, "{}")
 }
@@ -35,29 +40,34 @@ pub fn send_credential_ack(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/ack`
 pub fn receive_credential_ack(_options: &str, message: &str) -> StepResult {
     let parsed_message: Ack = serde_json::from_str(message)?;
-    let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
 
-    if !matches!(&parsed_message.body.user_type, UserType::Holder) {
-        return Err(Box::from(
-            "ACK for step 'done' message must be sent from Holder".to_string(),
-        ));
-    }
-    let current_user_type = UserType::Issuer;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+            if !matches!(&parsed_message.body.user_type, UserType::Holder) {
+                return Err(Box::from(
+                    "ACK for step 'done' message must be sent from Holder".to_string(),
+                ));
+            }
+            let current_user_type = UserType::Issuer;
 
-    match current_state {
-        State::SendIssueCredential => {
-            save_state(&thid, &State::Acknowledged, &parsed_message.body.user_type)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "State from {} to {} not allowed",
-                current_state,
-                State::Acknowledged
-            )))
-        }
-    };
+            let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+
+            match current_state {
+                State::SendIssueCredential => {
+                    save_state(&thid, &State::Acknowledged, &parsed_message.body.user_type)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "State from {} to {} not allowed",
+                        current_state,
+                        State::Acknowledged
+                    )))
+                }
+            };
+        } else { }
+}
 
     generate_step_output(message, "{}")
 }

--- a/src/protocols/issue_credential/holder.rs
+++ b/src/protocols/issue_credential/holder.rs
@@ -34,20 +34,24 @@ pub fn send_propose_credential(_options: &str, message: &str) -> StepResult {
 
     let thid = parsed_message.thid.ok_or("Thread id can't be empty.")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
 
-    match current_state {
-        State::ReceiveOfferCredential | State::Unknown => {
-            save_state(&thid, &State::SendProposeCredential, &UserType::Holder)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendProposeCredential
-            )))
-        }
-    };
+            match current_state {
+                State::ReceiveOfferCredential | State::Unknown => {
+                    save_state(&thid, &State::SendProposeCredential, &UserType::Holder)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendProposeCredential
+                    )))
+                }
+            };
+    } else { }
+    }
 
     let request_message = get_issue_credential_message(
         IssueCredentialType::ProposeCredential,
@@ -57,13 +61,17 @@ pub fn send_propose_credential(_options: &str, message: &str) -> StepResult {
         &thid,
     )?;
 
-    save_credential(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::SendProposeCredential,
-    )?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            save_credential(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::SendProposeCredential,
+            )?;
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&request_message)?, "{}")
 }
@@ -72,51 +80,55 @@ pub fn send_propose_credential(_options: &str, message: &str) -> StepResult {
 pub fn receive_offer_credential(_options: &str, message: &str) -> StepResult {
     let parsed_message: MessageWithBody<CredentialData> = serde_json::from_str(message)?;
 
-    let base_message: BaseMessage = BaseMessage {
-        body: HashMap::new(),
-        from: parsed_message.from.clone(),
-        r#type: parsed_message.r#type.clone(),
-        to: Some(
-            parsed_message
-                .to
-                .clone()
-                .ok_or("To DID not provided")?
-                .to_vec(),
-        ),
-    };
-    let thid = parsed_message
-        .thid
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let base_message: BaseMessage = BaseMessage {
+                body: HashMap::new(),
+                from: parsed_message.from.clone(),
+                r#type: parsed_message.r#type.clone(),
+                to: Some(
+                    parsed_message
+                        .to
+                        .clone()
+                        .ok_or("To DID not provided")?
+                        .to_vec(),
+                ),
+            };
+            let thid = parsed_message
+                .thid
+                .to_owned()
+                .ok_or("Thread id can't be empty")?;
 
-    let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
-    let base_info = get_from_to_from_message(&base_message)?;
-    let credential_data = exchange_info
-        .credential_data
-        .ok_or("Credential data not provided.")?;
+            let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
+            let base_info = get_from_to_from_message(&base_message)?;
+            let credential_data = exchange_info
+                .credential_data
+                .ok_or("Credential data not provided.")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
+            let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
 
-    match current_state {
-        State::SendProposeCredential => {
-            save_state(&thid, &State::ReceiveOfferCredential, &UserType::Holder)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "State from {} to {} not allowed",
-                current_state,
-                State::ReceiveOfferCredential
-            )))
-        }
-    };
+            match current_state {
+                State::SendProposeCredential => {
+                    save_state(&thid, &State::ReceiveOfferCredential, &UserType::Holder)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveOfferCredential
+                    )))
+                }
+            };
 
-    save_credential(
-        &base_info.to,
-        &base_info.from,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::ReceiveOfferCredential,
-    )?;
+            save_credential(
+                &base_info.to,
+                &base_info.from,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::ReceiveOfferCredential,
+            )?;
+        } else { }
+    }
 
     generate_step_output(message, "{}")
 }
@@ -137,20 +149,24 @@ pub fn send_request_credential(_options: &str, message: &str) -> StepResult {
     let credential_data: CredentialData = serde_json::from_str(data)?;
     let thid = parsed_message.thid.ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
 
-    match current_state {
-        State::ReceiveOfferCredential | State::Unknown => {
-            save_state(&thid, &State::SendRequestCredential, &UserType::Holder)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendRequestCredential
-            )))
-        }
-    };
+            match current_state {
+                State::ReceiveOfferCredential | State::Unknown => {
+                    save_state(&thid, &State::SendRequestCredential, &UserType::Holder)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendRequestCredential
+                    )))
+                }
+            };
+        } else { }
+    }
 
     let request_message = get_issue_credential_message(
         IssueCredentialType::RequestCredential,
@@ -160,13 +176,17 @@ pub fn send_request_credential(_options: &str, message: &str) -> StepResult {
         &thid,
     )?;
 
-    save_credential(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::SendRequestCredential,
-    )?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            save_credential(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::SendRequestCredential,
+            )?;
+            } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&request_message)?, "{}")
 }
@@ -187,39 +207,43 @@ pub fn receive_issue_credential(_options: &str, message: &str) -> StepResult {
                 .to_vec(),
         ),
     };
-    let thid = parsed_message
-        .thid
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = parsed_message
+                .thid
+                .to_owned()
+                .ok_or("Thread id can't be empty")?;
 
-    let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
-    let base_info = get_from_to_from_message(&base_message)?;
-    let credential_data = exchange_info
-        .credential_data
-        .ok_or("Credential data not provided.")?;
+            let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
+            let base_info = get_from_to_from_message(&base_message)?;
+            let credential_data = exchange_info
+                .credential_data
+                .ok_or("Credential data not provided.")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
+            let current_state: State = get_current_state(&thid, &UserType::Holder)?.parse()?;
 
-    match current_state {
-        State::SendRequestCredential => {
-            save_state(&thid, &State::ReceiveIssueCredential, &UserType::Holder)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ReceiveIssueCredential
-            )))
-        }
-    };
+            match current_state {
+                State::SendRequestCredential => {
+                    save_state(&thid, &State::ReceiveIssueCredential, &UserType::Holder)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveIssueCredential
+                    )))
+                }
+            };
 
-    save_credential(
-        &base_info.to,
-        &base_info.from,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::ReceiveIssueCredential,
-    )?;
+            save_credential(
+                &base_info.to,
+                &base_info.from,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::ReceiveIssueCredential,
+            )?;
+        } else { }
+    }
 
     generate_step_output(message, "{}")
 }

--- a/src/protocols/issue_credential/issuer.rs
+++ b/src/protocols/issue_credential/issuer.rs
@@ -41,27 +41,31 @@ pub fn send_offer_credential(_options: &str, message: &str) -> StepResult {
         &thid,
     )?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
-    match current_state {
-        State::ReceiveProposeCredential | State::Unknown => {
-            save_state(&thid, &State::SendOfferCredential, &UserType::Issuer)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendOfferCredential
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
+            match current_state {
+                State::ReceiveProposeCredential | State::Unknown => {
+                    save_state(&thid, &State::SendOfferCredential, &UserType::Issuer)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendOfferCredential
+                    )))
+                }
+            };
 
-    save_credential(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::SendOfferCredential,
-    )?;
+            save_credential(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::SendOfferCredential,
+            )?;
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&request_message)?, "{}")
 }
@@ -69,52 +73,57 @@ pub fn send_offer_credential(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/request_credential`
 pub fn receive_request_credential(_options: &str, message: &str) -> StepResult {
     let parsed_message: MessageWithBody<CredentialData> = serde_json::from_str(message)?;
-    let base_message: BaseMessage = BaseMessage {
-        body: HashMap::new(),
-        from: parsed_message.from.clone(),
-        r#type: parsed_message.r#type.clone(),
-        to: Some(
-            parsed_message
-                .to
-                .clone()
-                .ok_or("To DID not provided")?
-                .to_vec(),
-        ),
-    };
-    let thid = parsed_message
-        .thid
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
-    let base_info = get_from_to_from_message(&base_message)?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let base_message: BaseMessage = BaseMessage {
+                body: HashMap::new(),
+                from: parsed_message.from.clone(),
+                r#type: parsed_message.r#type.clone(),
+                to: Some(
+                    parsed_message
+                        .to
+                        .clone()
+                        .ok_or("To DID not provided")?
+                        .to_vec(),
+                ),
+            };
+            let thid = parsed_message
+                .thid
+                .to_owned()
+                .ok_or("Thread id can't be empty")?;
+            let base_info = get_from_to_from_message(&base_message)?;
 
-    match current_state {
-        State::SendOfferCredential | State::Unknown => {
-            save_state(&thid, &State::ReceiveRequestCredential, &UserType::Issuer)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ReceiveRequestCredential,
-            )))
-        }
-    };
+            let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
 
-    let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
+            match current_state {
+                State::SendOfferCredential | State::Unknown => {
+                    save_state(&thid, &State::ReceiveRequestCredential, &UserType::Issuer)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveRequestCredential,
+                    )))
+                }
+            };
 
-    let credential_data = exchange_info
-        .credential_data
-        .ok_or("Credential data not provided.")?;
+            let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
 
-    save_credential(
-        &base_info.from,
-        &base_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::ReceiveRequestCredential,
-    )?;
+            let credential_data = exchange_info
+                .credential_data
+                .ok_or("Credential data not provided.")?;
+
+            save_credential(
+                &base_info.from,
+                &base_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::ReceiveRequestCredential,
+            )?;
+    } else { }
+    }
 
     generate_step_output(message, "{}")
 }
@@ -122,52 +131,57 @@ pub fn receive_request_credential(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/propose-credential`
 pub fn receive_propose_credential(_options: &str, message: &str) -> StepResult {
     let parsed_message: MessageWithBody<CredentialData> = serde_json::from_str(message)?;
-    let base_message: BaseMessage = BaseMessage {
-        body: HashMap::new(),
-        from: parsed_message.from.clone(),
-        r#type: parsed_message.r#type.clone(),
-        to: Some(
-            parsed_message
-                .to
-                .clone()
-                .ok_or("To DID not provided")?
-                .to_vec(),
-        ),
-    };
 
-    let base_info = get_from_to_from_message(&base_message)?;
-    let thid = parsed_message
-        .thid
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let base_message: BaseMessage = BaseMessage {
+                body: HashMap::new(),
+                from: parsed_message.from.clone(),
+                r#type: parsed_message.r#type.clone(),
+                to: Some(
+                    parsed_message
+                        .to
+                        .clone()
+                        .ok_or("To DID not provided")?
+                        .to_vec(),
+                ),
+            };
 
-    let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
+            let base_info = get_from_to_from_message(&base_message)?;
+            let thid = parsed_message
+                .thid
+                .to_owned()
+                .ok_or("Thread id can't be empty")?;
 
-    let credential_data = exchange_info
-        .credential_data
-        .ok_or("Credential data not provided.")?;
+            let exchange_info = get_issue_credential_info_from_message(parsed_message)?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
-    match current_state {
-        State::SendOfferCredential | State::Unknown => {
-            save_state(&thid, &State::ReceiveProposeCredential, &UserType::Issuer)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ReceiveProposeCredential
-            )))
-        }
-    };
+            let credential_data = exchange_info
+                .credential_data
+                .ok_or("Credential data not provided.")?;
 
-    save_credential(
-        &base_info.from,
-        &base_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::ReceiveProposeCredential,
-    )?;
+            let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
+            match current_state {
+                State::SendOfferCredential | State::Unknown => {
+                    save_state(&thid, &State::ReceiveProposeCredential, &UserType::Issuer)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ReceiveProposeCredential
+                    )))
+                }
+            };
+
+            save_credential(
+                &base_info.from,
+                &base_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::ReceiveProposeCredential,
+            )?;
+        } else { }
+    }
 
     generate_step_output(message, "{}")
 }
@@ -196,27 +210,31 @@ pub fn send_issue_credential(_options: &str, message: &str) -> StepResult {
         &thid,
     )?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
-    match current_state {
-        State::ReceiveRequestCredential => {
-            save_state(&thid, &State::SendIssueCredential, &UserType::Issuer)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::SendIssueCredential
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let current_state: State = get_current_state(&thid, &UserType::Issuer)?.parse()?;
+            match current_state {
+                State::ReceiveRequestCredential => {
+                    save_state(&thid, &State::SendIssueCredential, &UserType::Issuer)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::SendIssueCredential
+                    )))
+                }
+            };
 
-    save_credential(
-        &exchange_info.from,
-        &exchange_info.to,
-        &thid,
-        &serde_json::to_string(&credential_data)?,
-        &State::SendIssueCredential,
-    )?;
+            save_credential(
+                &exchange_info.from,
+                &exchange_info.to,
+                &thid,
+                &serde_json::to_string(&credential_data)?,
+                &State::SendIssueCredential,
+            )?;
+    } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&request_message)?, "{}")
 }

--- a/src/protocols/issue_credential/problem_report.rs
+++ b/src/protocols/issue_credential/problem_report.rs
@@ -9,27 +9,32 @@ use crate::protocols::{
 /// Protocol handler for direction: `send`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/problem-report`
 pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report: ProblemReport = serde_json::from_str(message)?;
-    let problem_report_data = &problem_report.body;
-    let thid = problem_report
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
-    let current_state: State = get_current_state(thid, &problem_report_data.user_type)?.parse()?;
 
-    match current_state {
-        State::ReceiveProposeCredential | State::ReceiveOfferCredential => save_state(
-            thid,
-            &State::ProblemReported,
-            &problem_report_data.user_type,
-        )?,
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ProblemReported
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let problem_report_data = &problem_report.body;
+            let thid = problem_report
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
+            let current_state: State = get_current_state(thid, &problem_report_data.user_type)?.parse()?;
+
+            match current_state {
+                State::ReceiveProposeCredential | State::ReceiveOfferCredential => save_state(
+                    thid,
+                    &State::ProblemReported,
+                    &problem_report_data.user_type,
+                )?,
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ProblemReported
+                    )))
+                }
+            };
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&problem_report)?, "{}")
 }
@@ -37,34 +42,39 @@ pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `ISSUE_CREDENTIAL_PROTOCOL_URL/problem-report`
 pub fn receive_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report: ProblemReport = serde_json::from_str(message)?;
-    let thid = problem_report.thid.ok_or("Thread id can't be empty")?;
 
-    // flip sides to get current users type
-    let current_user_type = match &problem_report.body.user_type {
-        UserType::Issuer => UserType::Holder,
-        UserType::Holder => UserType::Issuer,
-        _ => {
-            return Err(Box::from(format!(
-                "invalid user type for problem report: {}",
-                &problem_report.body.user_type
-            )))
-        }
-    };
-    let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = problem_report.thid.ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::SendProposeCredential | State::SendOfferCredential => {
-            save_state(&thid, &State::ProblemReported, &current_user_type)?
-        }
+            // flip sides to get current users type
+            let current_user_type = match &problem_report.body.user_type {
+                UserType::Issuer => UserType::Holder,
+                UserType::Holder => UserType::Issuer,
+                _ => {
+                    return Err(Box::from(format!(
+                        "invalid user type for problem report: {}",
+                        &problem_report.body.user_type
+                    )))
+                }
+            };
+            let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
 
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ProblemReported
-            )))
-        }
-    };
+            match current_state {
+                State::SendProposeCredential | State::SendOfferCredential => {
+                    save_state(&thid, &State::ProblemReported, &current_user_type)?
+                }
+
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ProblemReported
+                    )))
+                }
+            };
+    } else { }
+    }
 
     generate_step_output(message, "{}")
 }

--- a/src/protocols/present_proof/done.rs
+++ b/src/protocols/present_proof/done.rs
@@ -12,24 +12,29 @@ use crate::{
 /// Protocol handler for direction: `send`, type: `PRESENT_PROOF_PROTOCOL_URL/ack`
 pub fn send_presentation_ack(_options: &str, message: &str) -> StepResult {
     let ack_message: MessageWithBody<AckData> = serde_json::from_str(message)?;
-    let thid = ack_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = ack_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::PresentationReceived => {
-            save_state(thid, &State::Acknowledged, &UserType::Verifier)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::Acknowledged
-            )))
-        }
+            let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
+
+            match current_state {
+                State::PresentationReceived => {
+                    save_state(thid, &State::Acknowledged, &UserType::Verifier)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::Acknowledged
+                    )))
+                }
+            }
+        } else { }
     }
 
     generate_step_output(&serde_json::to_string(&ack_message)?, "{}")
@@ -38,21 +43,26 @@ pub fn send_presentation_ack(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `PRESENT_PROOF_PROTOCOL_URL/ack`
 pub fn receive_presentation_ack(_options: &str, message: &str) -> StepResult {
     let ack_message: MessageWithBody<AckData> = serde_json::from_str(message)?;
-    let thid = ack_message.thid.ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Prover)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let thid = ack_message.thid.ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::PresentationSent => {
-            save_state(&thid, &State::Acknowledged, &UserType::Prover)?;
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::Acknowledged
-            )))
-        }
+            let current_state: State = get_current_state(&thid, &UserType::Prover)?.parse()?;
+
+            match current_state {
+                State::PresentationSent => {
+                    save_state(&thid, &State::Acknowledged, &UserType::Prover)?;
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::Acknowledged
+                    )))
+                }
+            }
+        } else { }
     }
 
     generate_step_output(message, "{}")

--- a/src/protocols/present_proof/problem_report.rs
+++ b/src/protocols/present_proof/problem_report.rs
@@ -12,35 +12,40 @@ use crate::{
 /// Protocol handler for direction: `send`, type: `PRESENT_PROOF_PROTOCOL_URL/problem-report`
 pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report_message: MessageWithBody<ProblemReportData> = serde_json::from_str(message)?;
-    let problem_report_data = problem_report_message
-        .body
-        .as_ref()
-        .ok_or("missing problem report data in body")?;
-    let thid = &problem_report_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
-    let current_state: State = get_current_state(thid, &problem_report_data.user_type)?.parse()?;
 
-    match current_state {
-        State::PresentationRequested
-        | State::PresentationRequestReceived
-        | State::PresentationSent
-        | State::PresentationReceived
-        | State::PresentationProposalReceived
-        | State::PresentationProposed => save_state(
-            thid,
-            &State::ProblemReported,
-            &problem_report_data.user_type,
-        )?,
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ProblemReported
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let problem_report_data = problem_report_message
+                .body
+                .as_ref()
+                .ok_or("missing problem report data in body")?;
+            let thid = &problem_report_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
+            let current_state: State = get_current_state(thid, &problem_report_data.user_type)?.parse()?;
+
+            match current_state {
+                State::PresentationRequested
+                | State::PresentationRequestReceived
+                | State::PresentationSent
+                | State::PresentationReceived
+                | State::PresentationProposalReceived
+                | State::PresentationProposed => save_state(
+                    thid,
+                    &State::ProblemReported,
+                    &problem_report_data.user_type,
+                )?,
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ProblemReported
+                    )))
+                }
+            };
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&problem_report_message)?, "{}")
 }
@@ -48,44 +53,49 @@ pub fn send_problem_report(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `PRESENT_PROOF_PROTOCOL_URL/problem-report`
 pub fn receive_problem_report(_options: &str, message: &str) -> StepResult {
     let problem_report_message: MessageWithBody<ProblemReportData> = serde_json::from_str(message)?;
-    let problem_report_data = problem_report_message
-        .body
-        .as_ref()
-        .ok_or("missing problem report data in body")?;
-    let thid = problem_report_message
-        .thid
-        .ok_or("Thread id can't be empty")?;
 
-    // flip sides to get current users type
-    let current_user_type = match &problem_report_data.user_type {
-        UserType::Prover => UserType::Verifier,
-        UserType::Verifier => UserType::Prover,
-        _ => {
-            return Err(Box::from(format!(
-                "invalid user type for problem report: {}",
-                &problem_report_data.user_type
-            )))
-        }
-    };
-    let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let problem_report_data = problem_report_message
+                .body
+                .as_ref()
+                .ok_or("missing problem report data in body")?;
+            let thid = problem_report_message
+                .thid
+                .ok_or("Thread id can't be empty")?;
 
-    match current_state {
-        State::PresentationRequested
-        | State::PresentationRequestReceived
-        | State::PresentationSent
-        | State::PresentationReceived
-        | State::PresentationProposalReceived
-        | State::PresentationProposed => {
-            save_state(&thid, &State::ProblemReported, &current_user_type)?
+            // flip sides to get current users type
+            let current_user_type = match &problem_report_data.user_type {
+                UserType::Prover => UserType::Verifier,
+                UserType::Verifier => UserType::Prover,
+                _ => {
+                    return Err(Box::from(format!(
+                        "invalid user type for problem report: {}",
+                        &problem_report_data.user_type
+                    )))
+                }
+            };
+            let current_state: State = get_current_state(&thid, &current_user_type)?.parse()?;
+
+            match current_state {
+                State::PresentationRequested
+                | State::PresentationRequestReceived
+                | State::PresentationSent
+                | State::PresentationReceived
+                | State::PresentationProposalReceived
+                | State::PresentationProposed => {
+                    save_state(&thid, &State::ProblemReported, &current_user_type)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::ProblemReported
+                    )))
+                }
+            };
+        } else { }
         }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::ProblemReported
-            )))
-        }
-    };
 
     generate_step_output(message, "{}")
 }

--- a/src/protocols/present_proof/prover.rs
+++ b/src/protocols/present_proof/prover.rs
@@ -13,37 +13,42 @@ use crate::{
 /// Protocol handler for direction: `send`, type: `PRESENT_PROOF_PROTOCOL_URL/presentation`
 pub fn send_presentation(_options: &str, message: &str) -> StepResult {
     let presentation_message: MessageWithBody<PresentationData> = serde_json::from_str(message)?;
-    let presentation_data = presentation_message
-        .body
-        .as_ref()
-        .ok_or("missing presentation data in body")?;
-    let from_to = presentation_message.get_from_to()?;
-    let thid = presentation_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(thid, &UserType::Prover)?.parse()?;
-    match current_state {
-        State::PresentationRequestReceived => {
-            save_state(thid, &State::PresentationSent, &UserType::Prover)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationSent
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let presentation_data = presentation_message
+                .body
+                .as_ref()
+                .ok_or("missing presentation data in body")?;
+            let from_to = presentation_message.get_from_to()?;
+            let thid = presentation_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
 
-    save_presentation(
-        &from_to.from,
-        &from_to.to,
-        thid,
-        &serde_json::to_string(&presentation_data)?,
-        &State::PresentationSent,
-    )?;
+            let current_state: State = get_current_state(thid, &UserType::Prover)?.parse()?;
+            match current_state {
+                State::PresentationRequestReceived => {
+                    save_state(thid, &State::PresentationSent, &UserType::Prover)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::PresentationSent
+                    )))
+                }
+            };
+
+            save_presentation(
+                &from_to.from,
+                &from_to.to,
+                thid,
+                &serde_json::to_string(&presentation_data)?,
+                &State::PresentationSent,
+            )?;
+        } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&presentation_message)?, "{}")
 }
@@ -51,39 +56,44 @@ pub fn send_presentation(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `PRESENT_PROOF_PROTOCOL_URL/request_presentation`
 pub fn receive_request_presentation(_options: &str, message: &str) -> StepResult {
     let request_message: MessageWithBody<RequestData> = serde_json::from_str(message)?;
-    let request_data = request_message
-        .body
-        .as_ref()
-        .ok_or("missing request data in body")?;
-    let from_to = request_message.get_from_to()?;
-    let thid = request_message
-        .thid
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(&thid, &UserType::Prover)?.parse()?;
-    match current_state {
-        State::PresentationProposed | State::Unknown => save_state(
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+        let request_data = request_message
+            .body
+            .as_ref()
+            .ok_or("missing request data in body")?;
+        let from_to = request_message.get_from_to()?;
+        let thid = request_message
+            .thid
+            .to_owned()
+            .ok_or("Thread id can't be empty")?;
+
+        let current_state: State = get_current_state(&thid, &UserType::Prover)?.parse()?;
+        match current_state {
+            State::PresentationProposed | State::Unknown => save_state(
+                &thid,
+                &State::PresentationRequestReceived,
+                &UserType::Prover,
+            )?,
+            _ => {
+                return Err(Box::from(format!(
+                    "Error while processing step: State from {} to {} not allowed",
+                    current_state,
+                    State::PresentationRequestReceived
+                )))
+            }
+        };
+
+        save_presentation(
+            &from_to.to,
+            &from_to.from,
             &thid,
+            &serde_json::to_string(&request_data)?,
             &State::PresentationRequestReceived,
-            &UserType::Prover,
-        )?,
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationRequestReceived
-            )))
-        }
-    };
-
-    save_presentation(
-        &from_to.to,
-        &from_to.from,
-        &thid,
-        &serde_json::to_string(&request_data)?,
-        &State::PresentationRequestReceived,
-    )?;
+        )?;
+    } else { }
+    }
 
     generate_step_output(message, "{}")
 }
@@ -91,44 +101,49 @@ pub fn receive_request_presentation(_options: &str, message: &str) -> StepResult
 /// Protocol handler for direction: `send`, type: `PRESENT_PROOF_PROTOCOL_URL/propose-presentation`
 pub fn send_propose_presentation(_options: &str, message: &str) -> StepResult {
     let proposal_message: MessageWithBody<ProposalData> = serde_json::from_str(message)?;
-    let proposal_data = proposal_message
-        .body
-        .as_ref()
-        .ok_or("missing proposal data in body")?;
-    if proposal_data.presentation_proposal.r#type != PROPOSAL_PROTOCOL_URL {
-        return Err(Box::from(format!(
-            r#"invalid type in proposal: "{}", must be "{}"#,
-            &proposal_data.presentation_proposal.r#type, PROPOSAL_PROTOCOL_URL
-        )));
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let proposal_data = proposal_message
+                .body
+                .as_ref()
+                .ok_or("missing proposal data in body")?;
+            if proposal_data.presentation_proposal.r#type != PROPOSAL_PROTOCOL_URL {
+                return Err(Box::from(format!(
+                    r#"invalid type in proposal: "{}", must be "{}"#,
+                    &proposal_data.presentation_proposal.r#type, PROPOSAL_PROTOCOL_URL
+                )));
+            }
+            let from_to = proposal_message.get_from_to()?;
+            let thid = proposal_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
+
+            let current_state: State = get_current_state(thid, &UserType::Prover)?.parse()?;
+
+            match current_state {
+                State::PresentationRequestReceived | State::Unknown => {
+                    save_state(thid, &State::PresentationProposed, &UserType::Prover)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::PresentationProposed
+                    )))
+                }
+            };
+
+            save_presentation(
+                &from_to.from,
+                &from_to.to,
+                thid,
+                &serde_json::to_string(&proposal_data)?,
+                &State::PresentationProposed,
+            )?;
+        } else { }
     }
-    let from_to = proposal_message.get_from_to()?;
-    let thid = proposal_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
-
-    let current_state: State = get_current_state(thid, &UserType::Prover)?.parse()?;
-
-    match current_state {
-        State::PresentationRequestReceived | State::Unknown => {
-            save_state(thid, &State::PresentationProposed, &UserType::Prover)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationProposed
-            )))
-        }
-    };
-
-    save_presentation(
-        &from_to.from,
-        &from_to.to,
-        thid,
-        &serde_json::to_string(&proposal_data)?,
-        &State::PresentationProposed,
-    )?;
 
     generate_step_output(&serde_json::to_string(&proposal_message)?, "{}")
 }

--- a/src/protocols/present_proof/verifier.rs
+++ b/src/protocols/present_proof/verifier.rs
@@ -13,37 +13,42 @@ use crate::{
 /// Protocol handler for direction: `send`, type: `PRESENT_PROOF_PROTOCOL_URL/request-presentation`
 pub fn send_request_presentation(_options: &str, message: &str) -> StepResult {
     let request_message: MessageWithBody<RequestData> = serde_json::from_str(message)?;
-    let request_data = request_message
-        .body
-        .as_ref()
-        .ok_or("missing request data in body")?;
-    let from_to = request_message.get_from_to()?;
-    let thid = request_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
-    match current_state {
-        State::PresentationProposalReceived | State::Unknown => {
-            save_state(thid, &State::PresentationRequested, &UserType::Verifier)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationRequested
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+    if #[cfg(feature = "state_storage")] {
+        let request_data = request_message
+            .body
+            .as_ref()
+            .ok_or("missing request data in body")?;
+        let from_to = request_message.get_from_to()?;
+        let thid = request_message
+            .thid
+            .as_ref()
+            .ok_or("Thread id can't be empty")?;
 
-    save_presentation(
-        &from_to.from,
-        &from_to.to,
-        thid,
-        &serde_json::to_string(&request_data)?,
-        &State::PresentationRequested,
-    )?;
+        let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
+        match current_state {
+            State::PresentationProposalReceived | State::Unknown => {
+                save_state(thid, &State::PresentationRequested, &UserType::Verifier)?
+            }
+            _ => {
+                return Err(Box::from(format!(
+                    "Error while processing step: State from {} to {} not allowed",
+                    current_state,
+                    State::PresentationRequested
+                )))
+            }
+        };
+
+        save_presentation(
+            &from_to.from,
+            &from_to.to,
+            thid,
+            &serde_json::to_string(&request_data)?,
+            &State::PresentationRequested,
+        )?;
+    } else { }
+    }
 
     generate_step_output(&serde_json::to_string(&request_message)?, "{}")
 }
@@ -51,37 +56,42 @@ pub fn send_request_presentation(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `PRESENT_PROOF_PROTOCOL_URL/presentation`
 pub fn receive_presentation(_options: &str, message: &str) -> StepResult {
     let presentation_message: MessageWithBody<PresentationData> = serde_json::from_str(message)?;
-    let presentation_data = presentation_message
-        .body
-        .as_ref()
-        .ok_or("missing presentation data in body")?;
-    let from_to = presentation_message.get_from_to()?;
-    let thid = presentation_message
-        .thid
-        .as_ref()
-        .ok_or("Thread id can't be empty")?;
 
-    let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
-    match current_state {
-        State::PresentationRequested => {
-            save_state(thid, &State::PresentationReceived, &UserType::Verifier)?
-        }
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationReceived
-            )))
-        }
-    };
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let presentation_data = presentation_message
+                .body
+                .as_ref()
+                .ok_or("missing presentation data in body")?;
+            let from_to = presentation_message.get_from_to()?;
+            let thid = presentation_message
+                .thid
+                .as_ref()
+                .ok_or("Thread id can't be empty")?;
 
-    save_presentation(
-        &from_to.from,
-        &from_to.to,
-        thid,
-        &serde_json::to_string(&presentation_data)?,
-        &State::PresentationReceived,
-    )?;
+            let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
+            match current_state {
+                State::PresentationRequested => {
+                    save_state(thid, &State::PresentationReceived, &UserType::Verifier)?
+                }
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::PresentationReceived
+                    )))
+                }
+            };
+
+            save_presentation(
+                &from_to.from,
+                &from_to.to,
+                thid,
+                &serde_json::to_string(&presentation_data)?,
+                &State::PresentationReceived,
+            )?;
+        } else { }
+    }
 
     generate_step_output(message, "{}")
 }
@@ -89,46 +99,51 @@ pub fn receive_presentation(_options: &str, message: &str) -> StepResult {
 /// Protocol handler for direction: `receive`, type: `PRESENT_PROOF_PROTOCOL_URL/propose-presentation`
 pub fn receive_propose_presentation(_options: &str, message: &str) -> StepResult {
     let proposal_message: MessageWithBody<ProposalData> = serde_json::from_str(message)?;
-    let proposal_data = proposal_message
-        .body
-        .as_ref()
-        .ok_or("missing proposal data in body")?;
-    if proposal_data.presentation_proposal.r#type != PROPOSAL_PROTOCOL_URL {
-        return Err(Box::from(format!(
-            r#"invalid type in proposal: "{}", must be "{}"#,
-            &proposal_data.presentation_proposal.r#type, PROPOSAL_PROTOCOL_URL
-        )));
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let proposal_data = proposal_message
+                .body
+                .as_ref()
+                .ok_or("missing proposal data in body")?;
+            if proposal_data.presentation_proposal.r#type != PROPOSAL_PROTOCOL_URL {
+                return Err(Box::from(format!(
+                    r#"invalid type in proposal: "{}", must be "{}"#,
+                    &proposal_data.presentation_proposal.r#type, PROPOSAL_PROTOCOL_URL
+                )));
+            }
+            let from_to = proposal_message.get_from_to()?;
+            let thid = proposal_message
+                .thid
+                .as_ref()
+                .to_owned()
+                .ok_or("Thread id can't be empty")?;
+
+            let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
+            match current_state {
+                State::PresentationRequested | State::Unknown => save_state(
+                    thid,
+                    &State::PresentationProposalReceived,
+                    &UserType::Verifier,
+                )?,
+                _ => {
+                    return Err(Box::from(format!(
+                        "Error while processing step: State from {} to {} not allowed",
+                        current_state,
+                        State::PresentationProposalReceived
+                    )))
+                }
+            };
+
+            save_presentation(
+                &from_to.from,
+                &from_to.to,
+                thid,
+                &serde_json::to_string(&proposal_data)?,
+                &State::PresentationProposalReceived,
+            )?;
+        } else { }
     }
-    let from_to = proposal_message.get_from_to()?;
-    let thid = proposal_message
-        .thid
-        .as_ref()
-        .to_owned()
-        .ok_or("Thread id can't be empty")?;
-
-    let current_state: State = get_current_state(thid, &UserType::Verifier)?.parse()?;
-    match current_state {
-        State::PresentationRequested | State::Unknown => save_state(
-            thid,
-            &State::PresentationProposalReceived,
-            &UserType::Verifier,
-        )?,
-        _ => {
-            return Err(Box::from(format!(
-                "Error while processing step: State from {} to {} not allowed",
-                current_state,
-                State::PresentationProposalReceived
-            )))
-        }
-    };
-
-    save_presentation(
-        &from_to.from,
-        &from_to.to,
-        thid,
-        &serde_json::to_string(&proposal_data)?,
-        &State::PresentationProposalReceived,
-    )?;
 
     generate_step_output(message, "{}")
 }

--- a/tests/did-exchange.rs
+++ b/tests/did-exchange.rs
@@ -19,7 +19,10 @@ use vade_didcomm::{
         VadeDidCommPluginReceiveOutput,
         VadeDidCommPluginSendOutput,
     },
-    protocols::did_exchange::{DidExchangeOptions, datatypes::{ProblemReportData, ProblemReport, UserType}},
+    protocols::did_exchange::{
+        datatypes::{ProblemReport, ProblemReportData, UserType},
+        DidExchangeOptions,
+    },
 };
 
 const DID_SERVICE_ENDPOINT: &str = "https://evan.network";
@@ -57,8 +60,6 @@ async fn send_request(
         .as_ref()
         .ok_or("no value in result")?;
     let prepared: VadeDidCommPluginSendOutput<Jwe> = serde_json::from_str(result)?;
-    let db_result = read_db(&format!("comm_keypair_{}_{}", sender, receiver))?;
-    let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
 
     let pub_key = prepared
         .metadata
@@ -76,9 +77,16 @@ async fn send_request(
         .ok_or("send DIDComm request does not return targetPubKey")?
         .to_owned();
 
-    assert_eq!(target_pub_key, comm_keypair.target_pub_key);
-    assert_eq!(pub_key, comm_keypair.pub_key);
-    assert_eq!(secret_key, comm_keypair.secret_key);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let db_result = read_db(&format!("comm_keypair_{}_{}", sender, receiver))?;
+            let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
+
+            assert_eq!(target_pub_key, comm_keypair.target_pub_key);
+            assert_eq!(pub_key, comm_keypair.pub_key);
+            assert_eq!(secret_key, comm_keypair.secret_key);
+        } else {}
+    }
 
     Ok(serde_json::to_string(&prepared.message)?)
 }
@@ -97,11 +105,11 @@ async fn receive_request(
     let received: VadeDidCommPluginReceiveOutput<
         MessageWithBody<DidDocumentBodyAttachment<Base64Container>>,
     > = serde_json::from_str(result)?;
+
     let target_did = received
         .metadata
         .get("keyAgreementKey")
         .ok_or("no keyAgreementKey")?;
-    let comm_keypair = get_com_keypair(target_did)?;
 
     let pub_key = received
         .metadata
@@ -119,9 +127,15 @@ async fn receive_request(
         .ok_or("send DIDComm request does not return targetPubKey")?
         .to_owned();
 
-    assert_eq!(target_pub_key, comm_keypair.target_pub_key);
-    assert_eq!(pub_key, comm_keypair.pub_key);
-    assert_eq!(secret_key, comm_keypair.secret_key);
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let comm_keypair = get_com_keypair(target_did)?;
+
+            assert_eq!(target_pub_key, comm_keypair.target_pub_key);
+            assert_eq!(pub_key, comm_keypair.pub_key);
+            assert_eq!(secret_key, comm_keypair.secret_key);
+        } else {}
+    }
 
     Ok(())
 }
@@ -178,13 +192,18 @@ async fn receive_response(
         .metadata
         .get("targetKeyAgreementKey")
         .ok_or("no targetKeyAgreementKey")?;
-    let comm_keypair_receiver = get_com_keypair(receiver_did)?;
-    let comm_keypair_sender = get_com_keypair(sender_did)?;
 
-    assert_eq!(
-        comm_keypair_sender.target_pub_key,
-        comm_keypair_receiver.pub_key
-    );
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            let comm_keypair_receiver = get_com_keypair(receiver_did)?;
+            let comm_keypair_sender = get_com_keypair(sender_did)?;
+
+            assert_eq!(
+                comm_keypair_sender.target_pub_key,
+                comm_keypair_receiver.pub_key
+            );
+        } else {}
+    }
 
     Ok(())
 }
@@ -320,6 +339,7 @@ async fn receive_problem_report(
 
 #[tokio::test]
 #[serial]
+#[cfg(feature = "state_storage")]
 async fn can_do_key_exchange_with_auto_generated_keys() -> Result<(), Box<dyn std::error::Error>> {
     let mut vade = get_vade().await?;
     let test_setup = get_keypair_set();
@@ -400,59 +420,77 @@ async fn can_do_key_exchange_pregenerated_keys() -> Result<(), Box<dyn std::erro
         serde_json::from_str(&test_setup.receiver_options_stringified)?;
     options_object.did_exchange_my_secret = Some(receiver_secret_key);
     let options_string = serde_json::to_string(&options_object)?;
+
     receive_request(&mut vade, request_message, &options_string).await?;
+
+    let mut receiver_options_string = test_setup.receiver_signing_options_stringified.to_owned();
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "state_storage"))] {
+            let mut receiver_options_object: DidExchangeOptions =
+                serde_json::from_str(&receiver_options_string)?;
+            receiver_options_object.did_exchange_my_secret = Some(receiver_secret_key);
+            receiver_options_string = serde_json::to_string(&receiver_options_object)?;
+        } else {}
+    };
 
     let response_message = send_response(
         &mut vade,
         &test_setup.user2_did,
         &test_setup.user1_did,
-        &test_setup.receiver_signing_options_stringified,
+        &receiver_options_string,
         &id,
     )
     .await?;
-    receive_response(
-        &mut vade,
-        response_message,
-        &test_setup.sender_signing_options_stringified,
-    )
-    .await?;
+
+    let mut sender_options_string = test_setup.sender_signing_options_stringified.to_owned();
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "state_storage"))] {
+            let mut sender_options_object: DidExchangeOptions =
+                serde_json::from_str(&sender_options_string)?;
+            sender_options_object.did_exchange_my_secret = Some(sender_secret_key);
+            sender_options_string = serde_json::to_string(&sender_options_object)?;
+        } else {}
+    };
+
+    receive_response(&mut vade, response_message, &sender_options_string).await?;
 
     let complete_message = send_complete(
         &mut vade,
         &test_setup.user1_did,
         &test_setup.user2_did,
-        &test_setup.sender_signing_options_stringified,
+        &sender_options_string,
         &id,
     )
     .await?;
-    receive_complete(
-        &mut vade,
-        complete_message,
-        &test_setup.receiver_signing_options_stringified,
-    )
-    .await?;
 
-    // check sender key
-    let db_result = read_db(&format!(
-        "comm_keypair_{}_{}",
-        &test_setup.user1_did, &test_setup.user2_did
-    ))?;
-    let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
-    assert_eq!(comm_keypair.secret_key, hex::encode(sender_secret_key));
+    receive_complete(&mut vade, complete_message, &receiver_options_string).await?;
 
-    // check receiver key
-    let db_result = read_db(&format!(
-        "comm_keypair_{}_{}",
-        &test_setup.user2_did, &test_setup.user1_did
-    ))?;
-    let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
-    assert_eq!(comm_keypair.secret_key, hex::encode(receiver_secret_key));
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "state_storage")] {
+            // check sender key
+            let db_result = read_db(&format!(
+                "comm_keypair_{}_{}",
+                &test_setup.user1_did, &test_setup.user2_did
+            ))?;
+            let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
+            assert_eq!(comm_keypair.secret_key, hex::encode(sender_secret_key));
+
+            // check receiver key
+            let db_result = read_db(&format!(
+                "comm_keypair_{}_{}",
+                &test_setup.user2_did, &test_setup.user1_did
+            ))?;
+            let comm_keypair: CommKeyPair = serde_json::from_str(&db_result)?;
+            assert_eq!(comm_keypair.secret_key, hex::encode(receiver_secret_key));
+        } else {}
+    }
 
     Ok(())
 }
 
 #[tokio::test]
 #[serial]
+#[cfg(feature = "state_storage")]
 async fn can_do_key_exchange_with_create_keys() -> Result<(), Box<dyn std::error::Error>> {
     let mut vade = get_vade().await?;
     let alice_keys = create_keys(&mut vade).await?;
@@ -522,6 +560,7 @@ async fn can_do_key_exchange_with_create_keys() -> Result<(), Box<dyn std::error
 
 #[tokio::test]
 #[serial]
+#[cfg(feature = "state_storage")]
 async fn can_report_problem() -> Result<(), Box<dyn std::error::Error>> {
     let mut vade = get_vade().await?;
     let alice_keys = create_keys(&mut vade).await?;
@@ -584,7 +623,7 @@ async fn can_report_problem() -> Result<(), Box<dyn std::error::Error>> {
         &id,
     )
     .await?;
-    
+
     receive_problem_report(
         &mut vade,
         &test_setup.user1_did,

--- a/tests/vade_didcomm.rs
+++ b/tests/vade_didcomm.rs
@@ -347,6 +347,7 @@ async fn can_prepare_unencrypted_didcomm_messages() -> Result<(), Box<dyn std::e
 
 #[tokio::test]
 #[serial]
+#[cfg(feature = "state_storage")]
 async fn should_store_messages_in_rocks_db() -> Result<(), Box<dyn std::error::Error>> {
     let mut vade = get_vade().await?;
 

--- a/utilities/src/keypair.rs
+++ b/utilities/src/keypair.rs
@@ -61,7 +61,10 @@ pub fn get_keypair_set() -> KeyPairSet {
         serde_json::to_string(&sender_options).unwrap_or_else(|_| "{}".to_string());
 
     let sender_signing_options: DidCommOptions = DidCommOptions {
-        encryption_keys: None,
+        encryption_keys: Some(EncryptionKeys {
+            encryption_my_secret: alice_secret_key.to_bytes(),
+            encryption_others_public: Some(bob_public.to_bytes()),
+        }),
         signing_keys: Some(SigningKeys {
             signing_my_secret: Some(sign_keypair.secret.to_bytes()),
             signing_others_public: Some(sign_keypair2.public.to_bytes()),
@@ -88,7 +91,10 @@ pub fn get_keypair_set() -> KeyPairSet {
         serde_json::to_string(&receiver_options).unwrap_or_else(|_| "{}".to_string());
 
     let receiver_signing_options: DidCommOptions = DidCommOptions {
-        encryption_keys: None,
+        encryption_keys: Some(EncryptionKeys {
+            encryption_my_secret: bob_secret_key.to_bytes(),
+            encryption_others_public: Some(alice_public.to_bytes()),
+        }),
         signing_keys: Some(SigningKeys {
             signing_my_secret: Some(sign_keypair2.secret.to_bytes()),
             signing_others_public: Some(sign_keypair.public.to_bytes()),


### PR DESCRIPTION
Adds feature `state_storage` that allows to disable db capabilities.

## Details

- `state_storage` skips rocks db interactions in protocol handling