### PR TITLE
Add comment field to did-exchange body

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,6 +18,7 @@
 - remove warnings when building/testing with and/or without `state_storage` feature
 - update dependency `didcomm-rs` to a fork without `resolve` feature
 - update dependencies for critical vulnerabilities
+- add `comment` field to `did-exchange` body
 
 ### Deprecations
 

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -136,6 +136,8 @@ pub struct DidDocumentBodyAttachment<T> {
     pub did_doc_attach: T,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
 }
 
 /// Decrypted messaged with dynamic body struct

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -130,6 +130,10 @@ pub fn get_did_exchange_message(
     let exchange_request: MessageWithBody<DidDocumentBodyAttachment<Base64Container>> =
         MessageWithBody {
             body: Some(DidDocumentBodyAttachment {
+                comment: match message.base_message.body.get("comment") {
+                    Some(label) => label.as_str().map(|v| v.to_string()),
+                    None => None,
+                },
                 did_doc_attach: Base64Container {
                     base64: base64_encoded_did_document,
                 },

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -130,10 +130,11 @@ pub fn get_did_exchange_message(
     let exchange_request: MessageWithBody<DidDocumentBodyAttachment<Base64Container>> =
         MessageWithBody {
             body: Some(DidDocumentBodyAttachment {
-                comment: match message.base_message.body.get("comment") {
-                    Some(label) => label.as_str().map(|v| v.to_string()),
-                    None => None,
-                },
+                comment: message
+                    .base_message
+                    .body
+                    .get("comment")
+                    .and_then(|label| label.as_str().map(|v| v.to_string())),
                 did_doc_attach: Base64Container {
                     base64: base64_encoded_did_document,
                 },

--- a/tests/did-exchange.rs
+++ b/tests/did-exchange.rs
@@ -49,6 +49,7 @@ async fn send_request(
             "to": ["{}"],
             "thid": "{}",
             "body": {{
+                "comment": "test",
                 "label": "test"
             }}
         }}"#,
@@ -144,10 +145,14 @@ async fn receive_request(
         } else {}
     }
     assert_eq!(
-        received.message.body.unwrap().label,
+        received.message.body.as_ref().unwrap().label,
         Some("test".to_string())
     );
 
+    assert_eq!(
+        received.message.body.unwrap().comment,
+        Some("test".to_string())
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

Currently the `DidDocumentBodyAttachment` struct in did-exchange protocol doesn't have `comment` property so it ignores it while parsing

## Details

- Add comment property for did-exchange body
- Update test
- Update versions.md