### PR TITLE
Fix pthid random value in get_did_exchange_message

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -18,6 +18,7 @@
 - remove warnings when building/testing with and/or without `state_storage` feature
 - update dependency `didcomm-rs` to a fork without `resolve` feature
 - update dependencies for critical vulnerabilities
+- fix `pthid` of message to be None, if not supplied
 
 ### Deprecations
 

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -147,7 +147,7 @@ pub fn get_did_exchange_message(
                 .or(Some(&fallback_id))
                 .map(|v| v.to_owned()),
             other: HashMap::new(),
-            pthid: message.pthid.or(None),
+            pthid: message.pthid,
             r#type: format!("{DID_EXCHANGE_PROTOCOL_URL}/{step_name}"),
             thid: message.thid.or(Some(service_id)),
             to: Some([String::from(to_did)].to_vec()),

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -149,7 +149,7 @@ pub fn get_did_exchange_message(
             other: HashMap::new(),
             pthid: message
                 .pthid
-                .or_else(|| Some(format!("{fallback_id}#key-1"))),
+                .or(None),
             r#type: format!("{DID_EXCHANGE_PROTOCOL_URL}/{step_name}"),
             thid: message.thid.or(Some(service_id)),
             to: Some([String::from(to_did)].to_vec()),

--- a/src/protocols/did_exchange/helper.rs
+++ b/src/protocols/did_exchange/helper.rs
@@ -147,9 +147,7 @@ pub fn get_did_exchange_message(
                 .or(Some(&fallback_id))
                 .map(|v| v.to_owned()),
             other: HashMap::new(),
-            pthid: message
-                .pthid
-                .or(None),
+            pthid: message.pthid.or(None),
             r#type: format!("{DID_EXCHANGE_PROTOCOL_URL}/{step_name}"),
             thid: message.thid.or(Some(service_id)),
             to: Some([String::from(to_did)].to_vec()),

--- a/tests/did-exchange.rs
+++ b/tests/did-exchange.rs
@@ -81,6 +81,7 @@ async fn send_request(
         .ok_or("send DIDComm request does not return targetPubKey")?
         .to_owned();
 
+    
     cfg_if::cfg_if! {
         if #[cfg(feature = "state_storage")] {
             let db_result = read_db(&format!("comm_keypair_{}_{}", sender, receiver))?;
@@ -148,6 +149,11 @@ async fn receive_request(
         Some("test".to_string())
     );
 
+    // pthid should not be optional and remain None if not supplied
+    assert_eq!(
+        received.message.pthid,
+        None
+    );
     Ok(())
 }
 

--- a/tests/did-exchange.rs
+++ b/tests/did-exchange.rs
@@ -81,7 +81,6 @@ async fn send_request(
         .ok_or("send DIDComm request does not return targetPubKey")?
         .to_owned();
 
-    
     cfg_if::cfg_if! {
         if #[cfg(feature = "state_storage")] {
             let db_result = read_db(&format!("comm_keypair_{}_{}", sender, receiver))?;
@@ -150,10 +149,7 @@ async fn receive_request(
     );
 
     // pthid should not be optional and remain None if not supplied
-    assert_eq!(
-        received.message.pthid,
-        None
-    );
+    assert_eq!(received.message.pthid, None);
     Ok(())
 }
 


### PR DESCRIPTION
## Description 

Pthid value in `get_did_exchange_message` function is currently filled with random UUID value, this should remain None if not supplied

## Details

- Fix pthid value to be optional 